### PR TITLE
Adding submodule initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ you will need [zig `0.16.0`](https://ziglang.org/download) to build revo
 
 ```bash
 git clone https://github.com/if-not-nil/revo && cd revo
+git submodule update --init --recursive
 zig build -Doptimize=ReleaseFast
 cp ./zig-out/bin/revo ~/.local/bin/revo
 


### PR DESCRIPTION
When i tried to download and install it there was an error, after checking a little bit i was able to see that you have a sub module that is not initialized called "vendor"  i would suggest this change or warn about the sub module in the docs, thanks for reading.