### PR TITLE
docs: Update build steps for lsp to say "lsp"

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ references, document symbols, and workspace symbols.
 to build:
 
 ```bash
-zig build revolt
+zig build lsp
 ```
 
 the binary lands at `zig-out/bin/revolt`

--- a/src/lsp/README.md
+++ b/src/lsp/README.md
@@ -11,7 +11,7 @@ the server builds on the great work done by the zls team, being [lsp-kit][#refer
 to build the server binary:
 
 ```bash
-zig build revolt
+zig build lsp
 ```
 
 the binary is then gonna be at `zig-out/bin/revolt`


### PR DESCRIPTION
Documentation says to do

```
zig build revolt
```

to build the lsp, but that build target doesn't exist. But the target `lsp` does and the follow command works.

```
zig build lsp
```