### PR TITLE
Zig 0.17.0, allocation errors, file:readdir() error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ zig-out
 # all dotfiles
 # .*
 *.so
+# meta.rvo output from examples
+*.rvo
 .priv
 .zig-cache
 /zig-pkg

--- a/src/lang/compiler/ir.zig
+++ b/src/lang/compiler/ir.zig
@@ -23,6 +23,7 @@ pub const IrBuilder = struct {
     pub fn init(alloc: std.mem.Allocator) !IrBuilder {
         return .{
             .alloc = alloc,
+            // 'alloc' will be an arena
             .instructions = try std.ArrayList(*IrInst).initCapacity(alloc, 32),
             .constants = try std.ArrayList([]const u8).initCapacity(alloc, 16),
         };

--- a/src/lang/compiler/state.zig
+++ b/src/lang/compiler/state.zig
@@ -49,6 +49,7 @@ pub const FunctionState = struct {
     pub fn init(alloc: std.mem.Allocator) !FunctionState {
         return .{
             .alloc = alloc,
+            // 'alloc' will be an arena
             .locals = try std.ArrayList(LocalVar).initCapacity(alloc, 8),
             .all_locals = try std.ArrayList(LocalVar).initCapacity(alloc, 8),
             .upvalues = try std.ArrayList(UpvalueSpec).initCapacity(alloc, 4),

--- a/src/lang/expander.zig
+++ b/src/lang/expander.zig
@@ -614,11 +614,17 @@ const PatternMatcher = struct {
     arg_idx: usize = 0,
 
     fn init(allocator: std.mem.Allocator, single_cap: usize) !PatternMatcher {
-        return .{
+        var self = PatternMatcher{
             .allocator = allocator,
-            .singles = try std.ArrayList(SingleCapture).initCapacity(allocator, single_cap),
-            .groups = try std.ArrayList(GroupCapture).initCapacity(allocator, 8),
+            .singles = undefined,
+            .groups = undefined,
         };
+        self.singles = try std.ArrayList(SingleCapture).initCapacity(allocator, single_cap);
+        errdefer self.singles.deinit(allocator);
+        self.groups = try std.ArrayList(GroupCapture).initCapacity(allocator, 8);
+        errdefer self.groups.deinit(allocator);
+        
+        return self;
     }
 
     fn deinit(self: *PatternMatcher) void {

--- a/src/lang/lang_pipeline.zig
+++ b/src/lang/lang_pipeline.zig
@@ -42,7 +42,8 @@ pub fn build(vm: *VM, source: Source, opts: BuildOptions) !BuildResult {
     var type_annotations = std.AutoHashMap(*const Node, compiler.types.TypeInfo).init(vm.runtime.alloc);
     defer type_annotations.deinit();
 
-    var known_globals = try std.ArrayList([]const u8).initCapacity(vm.runtime.alloc, 0);
+    var known_globals = try std.ArrayList([]const u8)
+        .initCapacity(vm.runtime.alloc, vm.const_globals.count());
     defer known_globals.deinit(vm.runtime.alloc);
     {
         var cit = vm.const_globals.keyIterator();

--- a/src/lang/semantic.zig
+++ b/src/lang/semantic.zig
@@ -96,17 +96,26 @@ const SemanticChecker = struct {
             .alloc = alloc,
             .source_name = source_name,
             .source = source,
-            .errors = try std.ArrayList(diagnostic.Part).initCapacity(alloc, 8),
-            .scopes = try std.ArrayList(Scope).initCapacity(alloc, 4),
+            .errors = undefined,
+            .scopes = undefined,
             .type_aliases = std.StringHashMap(types_mod.TypeInfo).init(alloc),
             .struct_layouts = std.StringHashMap([]const struct_layout.FieldDef).init(alloc),
-            .fn_sigs = try std.ArrayList(*FnSig).initCapacity(alloc, 4),
-            .return_types = try std.ArrayList(types_mod.TypeInfo).initCapacity(alloc, 4),
+            .fn_sigs = undefined,
+            .return_types = undefined,
             .type_map = type_map,
             .type_annotations = type_annotations,
             .typed_names = std.StringHashMap(void).init(alloc),
             .table_field_map = std.StringHashMap(std.StringHashMap(types_mod.TypeInfo)).init(alloc),
         };
+        checker.errors = try std.ArrayList(diagnostic.Part).initCapacity(alloc, 8);
+        errdefer checker.errors.deinit(alloc);
+        checker.scopes = try std.ArrayList(Scope).initCapacity(alloc, 4);
+        errdefer checker.scopes.deinit(alloc);
+        checker.fn_sigs = try std.ArrayList(*FnSig).initCapacity(alloc, 4);
+        errdefer checker.fn_sigs.deinit(alloc);
+        checker.return_types = try std.ArrayList(types_mod.TypeInfo).initCapacity(alloc, 4);
+        errdefer checker.return_types.deinit(alloc);
+        
         try checker.pushScope();
         // registers builtins
         for (known_globals) |name|

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -229,15 +229,24 @@ pub const Session = struct {
     project: revo.lang.Project = .{ .mode = .script, .root = "" },
 
     pub fn init(vm: *VM, gpa: Allocator, io: ?std.Io) !Session {
-        var project = if (io) |i| revo.lang.Project.detectFromCwd(i, gpa) else revo.lang.Project{ .mode = .script, .root = "" };
-        errdefer project.deinit(gpa);
-        return .{
+        var self = Session{
             .vm = vm,
             .gpa = gpa,
-            .workspace = try revo.lang.Workspace.initWithVm(vm, gpa),
-            .source_acc = try std.ArrayList(u8).initCapacity(gpa, 256),
-            .project = project,
+            .workspace = undefined,
+            .source_acc = undefined,
+            .project = undefined,
         };
+        self.project = if (io) |i|
+            .detectFromCwd(i, gpa)
+        else
+            .{ .mode = .script, .root = "" };
+        errdefer self.project.deinit(gpa);
+        self.workspace = try revo.lang.Workspace.initWithVm(vm, gpa);
+        errdefer self.workspace.deinit();
+        self.source_acc = try std.ArrayList(u8).initCapacity(gpa, 256);
+        errdefer self.source_acc.deinit(gpa);
+
+        return self;
     }
 
     pub fn deinit(self: *Session) void {

--- a/src/std/fs.zig
+++ b/src/std/fs.zig
@@ -338,7 +338,9 @@ fn readdir_meth_fn(args: []const Data, vm: *VM) !NativeResult {
     const handle = parseFileHandle(args[0], vm) catch return try NativeResult.Err(vm, "InvalidFile");
     const path = handle.path;
 
-    const open_dir = Dir.cwd().openDir(vm.runtime.io, path, .{}) catch |err| {
+    const open_dir = Dir.cwd().openDir(vm.runtime.io, path, .{
+        .iterate = true,
+    }) catch |err| {
         return try NativeResult.Err(vm, mapIOError(err));
     };
     defer open_dir.close(vm.runtime.io);
@@ -428,7 +430,9 @@ fn remove_fn(args: []const Data, vm: *VM) !NativeResult {
 fn readdir_fn(args: []const Data, vm: *VM) !NativeResult {
     const path = vm.stringValue(args[0].asString().?);
 
-    const open_dir = Dir.cwd().openDir(vm.runtime.io, path, .{}) catch |err| {
+    const open_dir = Dir.cwd().openDir(vm.runtime.io, path, .{
+        .iterate = true,
+    }) catch |err| {
         return try NativeResult.Err(vm, mapIOError(err));
     };
     defer open_dir.close(vm.runtime.io);

--- a/src/vm/VM.zig
+++ b/src/vm/VM.zig
@@ -152,7 +152,7 @@ loading_stack: std.ArrayList([]const u8),
 /// matches type enum order
 metatables: [
     @typeInfo(memory.Type).@"enum".fields.len
-]?mem.TableID = .{null} ** @typeInfo(memory.Type).@"enum".fields.len,
+]?mem.TableID = @splat(null),
 module_cache: ModuleCache,
 package_path: std.ArrayList([]const u8),
 debug_infos: std.ArrayList(DebugInfo),

--- a/src/vm/VM.zig
+++ b/src/vm/VM.zig
@@ -93,23 +93,36 @@ pub const Fiber = struct {
     waiters: std.ArrayList(FiberID),
 
     pub fn init(alloc: std.mem.Allocator, id: FiberID, program: []const Instruction, reg_count: usize) !Fiber {
-        return .{
+        var self = Fiber{
             .id = id,
             .pc = 0,
             .program = program,
             .debug_info_id = null,
-            .registers = try alloc.alloc(Data, reg_count),
-            .frames_hot = try std.ArrayList(FrameHot).initCapacity(alloc, MAX_FRAMES),
-            .frames_cold = try std.ArrayList(FrameCold).initCapacity(alloc, MAX_FRAMES),
-            .open_upvalues = try std.ArrayList(OpenUpvalueRef).initCapacity(alloc, 8),
+            .registers = undefined,
+            .frames_hot = undefined,
+            .frames_cold = undefined,
+            .open_upvalues = undefined,
             .running = false,
             .state = .ready,
             .in_runq = false,
             .wait = .none,
             .parked_result_slot = null,
-            .waiters = try std.ArrayList(FiberID).initCapacity(alloc, 2),
+            .waiters = undefined,
             .result = revo.core_atoms.data(.nil),
         };
+
+        self.registers = try alloc.alloc(Data, reg_count);
+        errdefer alloc.free(self.registers);
+        self.frames_hot = try std.ArrayList(FrameHot).initCapacity(alloc, MAX_FRAMES);
+        errdefer self.frames_hot.deinit(alloc);
+        self.frames_cold = try std.ArrayList(FrameCold).initCapacity(alloc, MAX_FRAMES);
+        errdefer self.frames_cold.deinit(alloc);
+        self.open_upvalues = try std.ArrayList(OpenUpvalueRef).initCapacity(alloc, 8);
+        errdefer self.open_upvalues.deinit(alloc);
+        self.waiters = try std.ArrayList(FiberID).initCapacity(alloc, 2);
+        errdefer self.waiters.deinit(alloc);
+
+        return self;
     }
 
     pub fn deinit(self: *Fiber, alloc: std.mem.Allocator) void {
@@ -197,28 +210,51 @@ pub fn init(runtime: revo.Runtime) !VM {
     errdefer rt.deinitDiagArena();
     var vm: VM = .{
         .runtime = rt,
-        .sched = try Scheduler.init(rt.alloc),
-        .constants = try std.ArrayList(Data).initCapacity(rt.alloc, 16),
+        .sched = undefined,
+        .constants = undefined,
         .stdlib_globals = Globals.init(rt.alloc),
-        .tables = try TablePool.init(rt.alloc),
-        .tuples = try TuplePool.init(rt.alloc),
-        .functions = try FunctionPool.init(rt.alloc),
+        .tables = undefined,
+        .tuples = undefined,
+        .functions = undefined,
         .struct_types = struct_mod.StructTypePool.init(rt.alloc),
-        .struct_instances = try struct_mod.StructInstancePool.init(rt.alloc),
-        .strings = try Interner.init(rt.alloc),
+        .struct_instances = undefined,
+        .strings = undefined,
         .atoms = std.StringHashMap(mem.AtomID).init(rt.alloc),
         .module_cache = ModuleCache.init(rt.alloc),
-        .package_path = try std.ArrayList([]const u8).initCapacity(rt.alloc, 4),
-        .debug_infos = try std.ArrayList(DebugInfo).initCapacity(rt.alloc, 8),
+        .package_path = undefined,
+        .debug_infos = undefined,
         .globals = Globals.init(rt.alloc),
         .const_globals = ConstGlobals.init(rt.alloc),
         .module_dir = null,
-        .loading_stack = try std.ArrayList([]const u8).initCapacity(rt.alloc, 1),
-        .loaded_extensions = try .initCapacity(rt.alloc, 0),
-        .gc_mark_stack = try std.ArrayList(MarkItem).initCapacity(rt.alloc, 256),
+        .loading_stack = undefined,
+        .loaded_extensions = .empty,
+        .gc_mark_stack = undefined,
     };
     try revo.async_backend_impl.init(&vm.runtime.async_backend);
     errdefer revo.async_backend_impl.deinit(&vm.runtime.async_backend);
+
+    vm.sched = try Scheduler.init(rt.alloc);
+    errdefer vm.sched.deinit();
+    vm.constants = try std.ArrayList(Data).initCapacity(rt.alloc, 16);
+    errdefer vm.constants.deinit(rt.alloc);
+    vm.tables = try TablePool.init(rt.alloc);
+    errdefer vm.tables.deinit();
+    vm.tuples = try TuplePool.init(rt.alloc);
+    errdefer vm.tuples.deinit();
+    vm.functions = try FunctionPool.init(rt.alloc);
+    errdefer vm.functions.deinit();
+    vm.struct_instances = try struct_mod.StructInstancePool.init(rt.alloc);
+    errdefer vm.struct_instances.deinit();
+    vm.strings = try Interner.init(rt.alloc);
+    errdefer vm.strings.deinit();
+    vm.package_path = try std.ArrayList([]const u8).initCapacity(rt.alloc, 4);
+    errdefer vm.package_path.deinit(rt.alloc);
+    vm.debug_infos = try std.ArrayList(DebugInfo).initCapacity(rt.alloc, 8);
+    errdefer vm.debug_infos.deinit(rt.alloc);
+    vm.loading_stack = try std.ArrayList([]const u8).initCapacity(rt.alloc, 1);
+    errdefer vm.loading_stack.deinit(rt.alloc);
+    vm.gc_mark_stack = try std.ArrayList(MarkItem).initCapacity(rt.alloc, 256);
+    errdefer vm.gc_mark_stack.deinit(rt.alloc);
 
     // init icache with max pc to force miss
     for (&vm.icache) |*entry| {

--- a/src/vm/debug.zig
+++ b/src/vm/debug.zig
@@ -106,9 +106,9 @@ pub const EvalFailure = struct {
     kind: EvalErrorKind,
     report: diagnostic.Report,
     part_len: usize = 0,
-    parts: [max_trace_frames + 2]diagnostic.Part = [_]diagnostic.Part{diagnostic.Part{ .@"error" = "" }} ** (max_trace_frames + 2),
+    parts: [max_trace_frames + 2]diagnostic.Part = @splat(diagnostic.Part{ .@"error" = "" }),
     trace_len: usize = 0,
-    trace: [max_trace_frames]TraceFrame = [_]TraceFrame{TraceFrame.empty()} ** max_trace_frames,
+    trace: [max_trace_frames]TraceFrame = @splat(TraceFrame.empty()),
 
     pub fn render(self: EvalFailure, alloc: std.mem.Allocator, writer: *std.Io.Writer, source: []const u8) !void {
         return self.renderAt(alloc, writer, self.report.source_name orelse "<source>", self.report.source orelse source);

--- a/src/vm/functions.zig
+++ b/src/vm/functions.zig
@@ -159,17 +159,31 @@ pub const FunctionPool = struct {
     segments: std.ArrayList([]const revo.Instruction),
 
     pub fn init(alloc: std.mem.Allocator) !FunctionPool {
-        return .{
+        var self = FunctionPool{
             .alloc = alloc,
-            .functions = try std.ArrayList(?Function).initCapacity(alloc, 16),
-            .function_marks = try std.DynamicBitSet.initEmpty(alloc, 64),
-            .function_dead = try std.ArrayList(mem.FunctionID).initCapacity(alloc, 0),
-            .prototypes = try std.ArrayList(Prototype).initCapacity(alloc, 16),
-            .upvalues = try std.ArrayList(?Upvalue).initCapacity(alloc, 16),
-            .upvalue_marks = try std.DynamicBitSet.initEmpty(alloc, 64),
-            .upvalue_dead = try std.ArrayList(UpvalueID).initCapacity(alloc, 0),
-            .segments = try std.ArrayList([]const revo.Instruction).initCapacity(alloc, 4),
+            .functions = undefined,
+            .function_marks = undefined,
+            .function_dead = .empty,
+            .prototypes = undefined,
+            .upvalues = undefined,
+            .upvalue_marks = undefined,
+            .upvalue_dead = .empty,
+            .segments = undefined,
         };
+        self.functions = try std.ArrayList(?Function).initCapacity(alloc, 16);
+        errdefer self.functions.deinit(alloc);
+        self.function_marks = try std.DynamicBitSet.initEmpty(alloc, 64);
+        errdefer self.function_marks.deinit();
+        self.prototypes = try std.ArrayList(Prototype).initCapacity(alloc, 16);
+        errdefer self.prototypes.deinit(alloc);
+        self.upvalues = try std.ArrayList(?Upvalue).initCapacity(alloc, 16);
+        errdefer self.upvalues.deinit(alloc);
+        self.upvalue_marks = try std.DynamicBitSet.initEmpty(alloc, 64);
+        errdefer self.upvalue_marks.deinit();
+        self.segments = try std.ArrayList([]const revo.Instruction).initCapacity(alloc, 4);
+        errdefer self.segments.deinit(alloc);
+
+        return self;
     }
 
     pub fn deinit(self: *FunctionPool) void {

--- a/src/vm/interner.zig
+++ b/src/vm/interner.zig
@@ -19,15 +19,19 @@ by_name: std.StringHashMap(memory.StringID),
 pub fn init(alloc: std.mem.Allocator) !Interner {
     var self = Interner{
         .alloc = alloc,
-        .slots = try std.ArrayList(?[]u8).initCapacity(
-            alloc,
-            @typeInfo(revo.core_atoms).@"enum".fields.len,
-        ),
-        .marks = try std.DynamicBitSet.initEmpty(alloc, 64),
-        .dead = try std.ArrayList(memory.StringID).initCapacity(alloc, 0),
+        .slots = undefined,
+        .marks = undefined,
+        .dead = .empty,
         .by_name = std.StringHashMap(memory.StringID).init(alloc),
     };
-    inline for (@typeInfo(revo.core_atoms).@"enum".fields) |field| {
+    const core_atoms_fields = @typeInfo(revo.core_atoms).@"enum".fields;
+
+    self.slots = try std.ArrayList(?[]u8).initCapacity(alloc, core_atoms_fields.len);
+    errdefer self.slots.deinit(alloc);
+    self.marks = try std.DynamicBitSet.initEmpty(alloc, 64);
+    errdefer self.marks.deinit();
+
+    inline for (core_atoms_fields) |field| {
         _ = try self.own(field.name);
     }
     return self;

--- a/src/vm/scheduler.zig
+++ b/src/vm/scheduler.zig
@@ -30,12 +30,20 @@ pub const ChannelState = struct {
     recv_head: usize = 0,
 
     pub fn init(alloc: std.mem.Allocator, cap: usize) !ChannelState {
-        return .{
+        var self = ChannelState{
             .cap = cap,
-            .queue = try std.ArrayList(Data).initCapacity(alloc, if (cap == 0) 1 else cap),
-            .send_waiters = try std.ArrayList(ChannelWaiter).initCapacity(alloc, 2),
-            .recv_waiters = try std.ArrayList(ChannelWaiter).initCapacity(alloc, 2),
+            .queue = undefined,
+            .send_waiters = undefined,
+            .recv_waiters = undefined,
         };
+        self.queue = try std.ArrayList(Data).initCapacity(alloc, if (cap == 0) 1 else cap);
+        errdefer self.queue.deinit(alloc);
+        self.send_waiters = try std.ArrayList(ChannelWaiter).initCapacity(alloc, 2);
+        errdefer self.send_waiters.deinit(alloc);
+        self.recv_waiters = try std.ArrayList(ChannelWaiter).initCapacity(alloc, 2);
+        errdefer self.recv_waiters.deinit(alloc);
+
+        return self;
     }
 
     pub fn deinit(self: *ChannelState, alloc: std.mem.Allocator) void {
@@ -194,19 +202,29 @@ waiting_cnt: usize,
 /// init with a 64-slot runq
 pub fn init(alloc: std.mem.Allocator) !@This() {
     const ring_cap = 64;
-    return .{
+    var self = Scheduler{
         .current_fiber = 0,
         .alloc = alloc,
-        .fibers = try std.ArrayList(Fiber).initCapacity(alloc, 1),
-        .ring_buf = try alloc.alloc(FiberID, ring_cap),
+        .fibers = undefined,
+        .ring_buf = undefined,
         .ring_head = 0,
         .ring_tail = 0,
         .ring_mask = ring_cap - 1,
-        .sleepers = try std.ArrayList(SleepWaiter).initCapacity(alloc, 4),
-        .io_waiters = try std.ArrayList(WaitEntry).initCapacity(alloc, 4),
-        .channels = std.AutoHashMap(ChannelID, ChannelState).init(alloc),
+        .sleepers = undefined,
+        .io_waiters = undefined,
+        .channels = .init(alloc),
         .waiting_cnt = 0,
     };
+    self.fibers = try std.ArrayList(Fiber).initCapacity(alloc, 1);
+    errdefer self.fibers.deinit(alloc);
+    self.ring_buf = try alloc.alloc(FiberID, ring_cap);
+    errdefer alloc.free(self.ring_buf);
+    self.sleepers = try std.ArrayList(SleepWaiter).initCapacity(alloc, 4);
+    errdefer self.sleepers.deinit(alloc);
+    self.io_waiters = try std.ArrayList(WaitEntry).initCapacity(alloc, 4);
+    errdefer self.io_waiters.deinit(alloc);
+
+    return self;
 }
 
 pub fn deinit(self: *@This()) void {

--- a/src/vm/struct.zig
+++ b/src/vm/struct.zig
@@ -36,7 +36,7 @@ pub const StructTypePool = struct {
     types: std.ArrayList(StructDescriptor),
 
     pub fn init(alloc: std.mem.Allocator) StructTypePool {
-        return .{ .alloc = alloc, .types = std.ArrayList(StructDescriptor).initCapacity(alloc, 0) catch unreachable };
+        return .{ .alloc = alloc, .types = .empty };
     }
 
     pub fn deinit(self: *StructTypePool) void {
@@ -125,12 +125,18 @@ pub const StructInstancePool = struct {
     dead: std.ArrayList(StructInstanceID),
 
     pub fn init(alloc: std.mem.Allocator) !StructInstancePool {
-        return .{
+        var self = StructInstancePool{
             .alloc = alloc,
-            .instances = try std.ArrayList(?StructInstance).initCapacity(alloc, 4),
-            .marks = try std.DynamicBitSet.initEmpty(alloc, 64),
-            .dead = try std.ArrayList(StructInstanceID).initCapacity(alloc, 0),
+            .instances = undefined,
+            .marks = undefined,
+            .dead = .empty,
         };
+        self.instances = try std.ArrayList(?StructInstance).initCapacity(alloc, 4);
+        errdefer self.instances.deinit(alloc);
+        self.marks = try std.DynamicBitSet.initEmpty(alloc, 64);
+        errdefer self.marks.deinit();
+
+        return self;
     }
 
     pub fn deinit(self: *StructInstancePool) void {

--- a/src/vm/table.zig
+++ b/src/vm/table.zig
@@ -33,12 +33,18 @@ pub const TablePool = struct {
     dead: std.ArrayList(memory.TableID),
 
     pub fn init(alloc: std.mem.Allocator) !TablePool {
-        return .{
+        var self = TablePool{
             .alloc = alloc,
-            .tables = try std.ArrayList(?Table).initCapacity(alloc, 4),
-            .marks = try std.DynamicBitSet.initEmpty(alloc, 64),
-            .dead = try std.ArrayList(memory.TableID).initCapacity(alloc, 0),
+            .tables = undefined,
+            .marks = undefined,
+            .dead = .empty,
         };
+        self.tables = try std.ArrayList(?Table).initCapacity(alloc, 4);
+        errdefer self.tables.deinit(alloc);
+        self.marks = try std.DynamicBitSet.initEmpty(alloc, 64);
+        errdefer self.marks.deinit();
+
+        return self;
     }
 
     pub fn deinit(self: *TablePool) void {
@@ -52,11 +58,11 @@ pub const TablePool = struct {
 
     pub fn create(self: *TablePool) !memory.TableID {
         if (self.dead.pop()) |id| {
-            self.tables.items[id] = try Table.init(self.alloc);
+            self.tables.items[id] = Table.init(self.alloc);
             return id;
         }
         const id: memory.TableID = @intCast(self.tables.items.len);
-        try self.tables.append(self.alloc, try Table.init(self.alloc));
+        try self.tables.append(self.alloc, Table.init(self.alloc));
         if (id >= self.marks.capacity()) {
             try self.marks.resize(self.tables.items.len, false);
         }
@@ -336,10 +342,10 @@ pub const Table = struct {
     metatable: ?memory.TableID = null,
     ic_version: usize = 0,
 
-    pub fn init(alloc: std.mem.Allocator) !Table {
+    pub fn init(alloc: std.mem.Allocator) Table {
         return .{
             .alloc = alloc,
-            .array = try std.ArrayList(Data).initCapacity(alloc, 0),
+            .array = .empty,
             .hash = .{},
         };
     }
@@ -544,7 +550,7 @@ test "table float keys stay distinct when non integral" {
 }
 
 test "table push appends positional values" {
-    var table = try Table.init(std.testing.allocator);
+    var table = Table.init(std.testing.allocator);
     defer table.deinit();
 
     try table.push(Data.new.num(10));
@@ -564,7 +570,7 @@ const tt = revo.lang.testing;
 //
 
 test "putRaw: integer key in range 0..<len overwrites existing element" {
-    var table = try Table.init(std.testing.allocator);
+    var table = Table.init(std.testing.allocator);
     defer table.deinit();
     try table.push(Data.new.num(10));
     try table.push(Data.new.num(20));
@@ -578,7 +584,7 @@ test "putRaw: integer key in range 0..<len overwrites existing element" {
 }
 
 test "putRaw: integer key == len appends to array" {
-    var table = try Table.init(std.testing.allocator);
+    var table = Table.init(std.testing.allocator);
     defer table.deinit();
     try table.push(Data.new.num(10));
     try table.push(Data.new.num(20));
@@ -589,7 +595,7 @@ test "putRaw: integer key == len appends to array" {
 }
 
 test "putRaw: integer key > len goes to hash" {
-    var table = try Table.init(std.testing.allocator);
+    var table = Table.init(std.testing.allocator);
     defer table.deinit();
     try table.push(Data.new.num(10));
 
@@ -599,7 +605,7 @@ test "putRaw: integer key > len goes to hash" {
 }
 
 test "putRaw: negative integer key always goes to hash" {
-    var table = try Table.init(std.testing.allocator);
+    var table = Table.init(std.testing.allocator);
     defer table.deinit();
     try table.push(Data.new.num(10));
 
@@ -609,7 +615,7 @@ test "putRaw: negative integer key always goes to hash" {
 }
 
 test "putRaw: float key always goes to hash" {
-    var table = try Table.init(std.testing.allocator);
+    var table = Table.init(std.testing.allocator);
     defer table.deinit();
 
     try table.putRaw(Data.new.num(1.5), Data.new.num(99));
@@ -618,7 +624,7 @@ test "putRaw: float key always goes to hash" {
 }
 
 test "putRaw: NaN and Infinity keys go to hash" {
-    var table = try Table.init(std.testing.allocator);
+    var table = Table.init(std.testing.allocator);
     defer table.deinit();
 
     try table.putRaw(Data.new.num(std.math.nan(f64)), Data.new.num(1));
@@ -628,7 +634,7 @@ test "putRaw: NaN and Infinity keys go to hash" {
 }
 
 test "putRaw: getRaw retrieves from array for integer keys" {
-    var table = try Table.init(std.testing.allocator);
+    var table = Table.init(std.testing.allocator);
     defer table.deinit();
     try table.push(Data.new.num(10));
     try table.push(Data.new.num(20));
@@ -639,7 +645,7 @@ test "putRaw: getRaw retrieves from array for integer keys" {
 }
 
 test "putRaw: getRaw retrieves from hash for negative and float keys" {
-    var table = try Table.init(std.testing.allocator);
+    var table = Table.init(std.testing.allocator);
     defer table.deinit();
     try table.putRaw(Data.new.num(-1), Data.new.num(42));
     try table.putRaw(Data.new.num(1.5), Data.new.num(99));
@@ -649,7 +655,7 @@ test "putRaw: getRaw retrieves from hash for negative and float keys" {
 }
 
 test "putRaw: integer key > len in empty table goes to hash" {
-    var table = try Table.init(std.testing.allocator);
+    var table = Table.init(std.testing.allocator);
     defer table.deinit();
 
     try table.putRaw(Data.new.num(0), Data.new.num(10));

--- a/src/vm/tuple.zig
+++ b/src/vm/tuple.zig
@@ -31,12 +31,18 @@ pub const TuplePool = struct {
     dead: std.ArrayList(memory.TupleID),
 
     pub fn init(alloc: std.mem.Allocator) !TuplePool {
-        return .{
+        var self = TuplePool{
             .alloc = alloc,
-            .tuples = try std.ArrayList(?Tuple).initCapacity(alloc, 4),
-            .marks = try std.DynamicBitSet.initEmpty(alloc, 64),
-            .dead = try std.ArrayList(memory.TupleID).initCapacity(alloc, 0),
+            .tuples = undefined,
+            .marks = undefined,
+            .dead = .empty,
         };
+        self.tuples = try std.ArrayList(?Tuple).initCapacity(alloc, 4);
+        errdefer self.tuples.deinit(alloc);
+        self.marks = try std.DynamicBitSet.initEmpty(alloc, 64);
+        errdefer self.marks.deinit();
+
+        return self;
     }
 
     pub fn deinit(self: *TuplePool) void {


### PR DESCRIPTION
~~By zig 0.17.0 the slice multiplication operator (`**`) will get removed, and is recommended to be replaced with `@splat()`.\
\
This is a small fix but will prevent future annoying build error when switching to zig 0.17.0 in the future.~~

### Edit

This pull request got every following commits included within, which was not my intention, though let's shoot 4 birds with one stone eh:

- Zig 0.17.0 will remove `**` operator in favor of `@splat()`, so I changed every instances of it.
- Some init() functions inside compiler/ and vm/ used `ArrayList(T).intiCapacity` without an `errdefer`, I know this is largely unprobable to happen, but this is still a potential memory leak. As well as call `initCapacity(alloc, 0)` are basically identical to `.empty`.
- Running `examples/all.sh` creates a `meta.rvo` file in root, so I added it to the gitignore file.
- stdlib's `file:readdir()` would error with `EBADF` because `.iterate` was not `true` in the `openDir` function's options argument
