### PR TITLE
asyn job buffer leak patch

### DIFF
--- a/src/runtime/async_backend_posix.zig
+++ b/src/runtime/async_backend_posix.zig
@@ -183,6 +183,7 @@ fn process_completion(vm: *revo.VM, rec: CompletionRecord) !void {
     }
 
     // owned by backend after submit
+    if (job.buffer) |buf| vm.runtime.alloc.free(buf);
     vm.runtime.alloc.destroy(job);
 }
 


### PR DESCRIPTION
in the posix backend impl, the submit function allocates memory for job.buffer. but it never gets deallocated and memory leaks. this patch frees the allocation just right before the line when job gets destroyed process_completion. free is called if job.buffer != null. i came across this when i ran the socket:send function. i tested all other functions in the net modules with small inputs and they didnt leak anything. but thats pretty much it.