### PR TITLE
fix stale pool pointer use after frees and make them impossible

### DIFF
--- a/src/std/json.zig
+++ b/src/std/json.zig
@@ -157,10 +157,17 @@ fn arrayToData(items: []const json.Value, vm: *VM) anyerror!Data {
 
 fn objectToData(object: json.ObjectMap, vm: *VM) anyerror!Data {
     const table_id = try vm.tables.create();
-    const table = try vm.tables.get(table_id);
     var it = object.iterator();
     while (it.next()) |entry| {
-        try table.putRawAtom(try vm.internAtom(entry.key_ptr.*), try fromJsonValue(entry.value_ptr.*, vm), vm);
+        const atom = try vm.internAtom(entry.key_ptr.*);
+        // fromJsonValue recurses on nested objects/arrays and can call
+        // vm.tables.create()/vm.tuples.create(), which may reallocate the pool
+        // backing store. re-fetch the table afterwards instead of holding a
+        // pointer across the recursion, or the putRawAtom below writes through
+        // a dangling pointer.
+        const value = try fromJsonValue(entry.value_ptr.*, vm);
+        const table = try vm.tables.get(table_id);
+        try table.putRawAtom(atom, value, vm);
     }
     return Data.new.table(table_id);
 }
@@ -175,4 +182,16 @@ test "json encode and decode round trip" {
     try testing.topNumber(
         \\ json.decode("{{ \"a\" : 1}}"):unwrap().a
     , 1);
+}
+
+test "json decode of nested objects does not use a stale table pointer" {
+    const testing = revo.lang.testing;
+
+    // decoding nested objects recurses through objectToData, which calls
+    // vm.tables.create() and can reallocate the table pool. the outer decode
+    // must re-fetch its table each step rather than write through a pointer
+    // taken before the recursion.
+    try testing.topNumber(
+        \\ json.decode("{{ \"a\" : {{ \"b\" : {{ \"c\" : 42 }} }} }}"):unwrap().a.b.c
+    , 42);
 }

--- a/src/std/root.zig
+++ b/src/std/root.zig
@@ -354,15 +354,18 @@ pub fn dosuite(args: []const Data, vm: *VM) !HostResult {
 pub fn debug_(args: []const Data, vm: *VM) !HostResult {
     _ = args;
 
-    const out_id = try vm.tables.create();
-    const out = try vm.tables.get(out_id);
-
+    // build the flags table first: every vm.tables.create() can reallocate the
+    // pool backing store, so the `out` pointer must be taken *after* the last
+    // table creation. otherwise the writes through `out` below hit freed memory.
     const flags_id = try vm.tables.create();
     const flags = try vm.tables.get(flags_id);
     try flags.putRawAtom(try vm.internAtom("dump"), Data.new.boolean(vm.debug.dump), vm);
     try flags.putRawAtom(try vm.internAtom("trace"), Data.new.boolean(vm.debug.trace), vm);
     try flags.putRawAtom(try vm.internAtom("instr"), Data.new.boolean(vm.debug.each_instr), vm);
     try flags.putRawAtom(try vm.internAtom("stack"), Data.new.boolean(vm.debug.each_stack), vm);
+
+    const out_id = try vm.tables.create();
+    const out = try vm.tables.get(out_id);
     try out.putRawAtom(try vm.internAtom("flags"), Data.new.table(flags_id), vm);
 
     const fiber = vm.currentFiber();
@@ -1017,6 +1020,16 @@ test "type predicates" {
     try testing.topFalse("struct Foo { x = 1 } struct_val?(42)");
     try testing.topTrue("struct Foo { x = 1 } struct_type?(Foo)");
     try testing.topFalse("struct Foo { x = 1 } struct_type?(42)");
+}
+
+test "debug() links its nested flags table without a stale pointer" {
+    // debug() creates the `out` table, then creates a second `flags` table.
+    // the second create can reallocate the table pool, so `out` must be
+    // fetched after it. these checks fail (or trip the allocator) if `out`
+    // is written through a dangling pointer.
+    try testing.topTrue("table?(debug().flags)");
+    try testing.topFalse("debug().flags.dump");
+    try testing.topTrue("num?(debug().stack_depth)");
 }
 
 test "array methods" {

--- a/src/vm/VM.zig
+++ b/src/vm/VM.zig
@@ -1250,7 +1250,7 @@ pub inline fn tableFast(
         std.debug.assert(
             self.tables.tables.items[id] != null,
         );
-        return &self.tables.tables.items[id].?;
+        return self.tables.tables.items[id].?;
     }
     return self.tables.get(id);
 }
@@ -1266,7 +1266,7 @@ inline fn functionFast(
         std.debug.assert(
             self.functions.functions.items[id] != null,
         );
-        return &self.functions.functions.items[id].?;
+        return self.functions.functions.items[id].?;
     }
     return self.functions.get(id) catch |e| {
         if (e == error.FunctionDNE) {

--- a/src/vm/functions.zig
+++ b/src/vm/functions.zig
@@ -118,14 +118,18 @@ pub const Function = union(enum) {
 
 pub const FunctionPool = struct {
     alloc: std.mem.Allocator,
-    functions: std.ArrayList(?Function),
+    // boxed: function/upvalue slots hold stable pointers, so a *Function or
+    // *Upvalue from get() survives later create() calls.
+    function_box_pool: std.heap.MemoryPool(Function),
+    functions: std.ArrayList(?*Function),
     function_marks: std.DynamicBitSet,
     function_dead: std.ArrayList(mem.FunctionID),
     function_first: usize = pool.end,
     function_last: usize = pool.end,
     function_next: std.ArrayList(usize),
     prototypes: std.ArrayList(Prototype),
-    upvalues: std.ArrayList(?Upvalue),
+    upvalue_box_pool: std.heap.MemoryPool(Upvalue),
+    upvalues: std.ArrayList(?*Upvalue),
     upvalue_marks: std.DynamicBitSet,
     upvalue_dead: std.ArrayList(UpvalueID),
     upvalue_first: usize = pool.end,
@@ -136,11 +140,13 @@ pub const FunctionPool = struct {
     pub fn init(alloc: std.mem.Allocator) !FunctionPool {
         return FunctionPool{
             .alloc = alloc,
+            .function_box_pool = .empty,
             .functions = try .initCapacity(alloc, 16),
             .function_marks = try .initEmpty(alloc, 64),
             .function_dead = .empty,
             .function_next = try .initCapacity(alloc, 16),
             .prototypes = try .initCapacity(alloc, 16),
+            .upvalue_box_pool = .empty,
             .upvalues = try .initCapacity(alloc, 16),
             .upvalue_marks = try .initEmpty(alloc, 64),
             .upvalue_dead = .empty,
@@ -150,8 +156,8 @@ pub const FunctionPool = struct {
     }
 
     pub fn deinit(self: *FunctionPool) void {
-        for (self.functions.items) |*maybe_f| {
-            if (maybe_f.*) |f| switch (f) {
+        for (self.functions.items) |maybe_f| {
+            if (maybe_f) |f| switch (f.*) {
                 .closure => |closure| self.alloc.free(closure.upvalues),
                 .c_function => {},
                 .host => {},
@@ -164,6 +170,8 @@ pub const FunctionPool = struct {
             self.alloc.free(proto.const_local_bits);
         }
         for (self.segments.items) |seg| self.alloc.free(seg);
+        self.function_box_pool.deinit(self.alloc);
+        self.upvalue_box_pool.deinit(self.alloc);
         self.functions.deinit(self.alloc);
         self.function_marks.deinit();
         self.function_dead.deinit(self.alloc);
@@ -181,6 +189,7 @@ pub const FunctionPool = struct {
             self.alloc,
             Function,
             mem.FunctionID,
+            &self.function_box_pool,
             &self.functions,
             &self.function_marks,
             &self.function_dead,
@@ -265,6 +274,7 @@ pub const FunctionPool = struct {
             self.alloc,
             Upvalue,
             UpvalueID,
+            &self.upvalue_box_pool,
             &self.upvalues,
             &self.upvalue_marks,
             &self.upvalue_dead,
@@ -277,7 +287,7 @@ pub const FunctionPool = struct {
 
     pub inline fn get(self: *FunctionPool, id: mem.FunctionID) !*Function {
         if (id >= self.functions.items.len) return error.FunctionDNE;
-        if (self.functions.items[id]) |*f| return f;
+        if (self.functions.items[id]) |f| return f;
         return error.FunctionDNE;
     }
 
@@ -288,7 +298,7 @@ pub const FunctionPool = struct {
 
     pub inline fn getUpvalue(self: *FunctionPool, id: UpvalueID) !*Upvalue {
         if (id >= self.upvalues.items.len) return error.FunctionDNE;
-        if (self.upvalues.items[id]) |*u| return u;
+        if (self.upvalues.items[id]) |u| return u;
         return error.FunctionDNE;
     }
 
@@ -313,6 +323,7 @@ pub const FunctionPool = struct {
             self.alloc,
             Function,
             mem.FunctionID,
+            &self.function_box_pool,
             &self.functions,
             &self.function_marks,
             &self.function_dead,
@@ -326,6 +337,7 @@ pub const FunctionPool = struct {
             self.alloc,
             Upvalue,
             UpvalueID,
+            &self.upvalue_box_pool,
             &self.upvalues,
             &self.upvalue_marks,
             &self.upvalue_dead,
@@ -342,7 +354,7 @@ pub const FunctionPool = struct {
         while (fid != pool.end) {
             const f = self.functions.items[fid].?;
             total += 48;
-            switch (f) {
+            switch (f.*) {
                 .closure => |closure| total += @sizeOf(UpvalueID) * closure.upvalues.len,
                 .host, .c_function => {},
             }
@@ -366,17 +378,14 @@ pub const FunctionPool = struct {
     }
 };
 
-fn freeFunction(f: *Function, alloc: std.mem.Allocator) ?Function {
+fn freeFunction(f: *Function, alloc: std.mem.Allocator) void {
     switch (f.*) {
         .closure => |closure| alloc.free(closure.upvalues),
         .host, .c_function => {},
     }
-    return null;
 }
 
-fn freeUpvalue(_: *Upvalue, _: std.mem.Allocator) ?Upvalue {
-    return null;
-}
+fn freeUpvalue(_: *Upvalue, _: std.mem.Allocator) void {}
 
 test "functions call with lexical locals" {
     try t.topNumber(

--- a/src/vm/gc.zig
+++ b/src/vm/gc.zig
@@ -115,7 +115,7 @@ pub fn processMarkStack(self: *VM) void {
                 if (id >= self.functions.functions.items.len) continue;
 
                 const func = self.functions.functions.items[id] orelse continue;
-                switch (func) {
+                switch (func.*) {
                     .closure => |closure| {
                         for (closure.upvalues) |upvalue_id|
                             self.functions.markUpvalue(upvalue_id, self);

--- a/src/vm/pool.zig
+++ b/src/vm/pool.zig
@@ -27,12 +27,17 @@ pub inline fn relink(first: *usize, last: *usize, next: *std.ArrayList(usize), i
     last.* = id;
 }
 
-/// append a brand new value to a pool, reusing a dead slot if one exists
+/// append a brand new value to a pool, reusing a dead slot if one exists.
+///
+/// values are boxed: the slot array holds stable *T pointers so a pointer from
+/// a pool's get() stays valid across later create() calls. the boxes come from
+/// box_pool (arena-backed) and are handed back to it on sweep.
 pub fn create(
     alloc: std.mem.Allocator,
     comptime T: type,
     comptime ID: type,
-    items: *std.ArrayList(?T),
+    box_pool: *std.heap.MemoryPool(T),
+    items: *std.ArrayList(?*T),
     marks: *std.DynamicBitSet,
     dead: *std.ArrayList(ID),
     first: *usize,
@@ -41,7 +46,10 @@ pub fn create(
     value: T,
 ) !ID {
     if (dead.pop()) |id| {
-        items.items[id] = value;
+        errdefer dead.appendAssumeCapacity(id); // restore the id on failure
+        const box = try box_pool.create(alloc);
+        box.* = value;
+        items.items[id] = box;
         relink(first, last, next, id);
         return id;
     }
@@ -49,7 +57,10 @@ pub fn create(
     if (id >= marks.capacity()) {
         try marks.resize(id + 1, false);
     }
-    try items.append(alloc, value);
+    const box = try box_pool.create(alloc);
+    errdefer box_pool.destroy(box);
+    box.* = value;
+    try items.append(alloc, box);
     errdefer _ = items.pop();
     try link(first, last, next, alloc, id);
     return id;
@@ -59,20 +70,21 @@ pub fn create(
 /// clearing the marks of survivors. the list always contains exactly the
 /// live slots, so this touches only what marking survived
 ///
-/// the free fn returns an optional replacement: null drops the slot (thats
-/// just how it used to be before, slot becomes null), non-null keeps it, used by
-/// Table to retain its dense-array buffer across collections
+/// `free` releases a dead value's owned resources; the box is then returned to
+/// box_pool and the slot nulled, so liveness stays exactly `slot != null` (the
+/// same contract get()/mark()/isValid() relied on before boxing)
 pub fn sweep(
     alloc: std.mem.Allocator,
     comptime T: type,
     comptime ID: type,
-    items: *std.ArrayList(?T),
+    box_pool: *std.heap.MemoryPool(T),
+    items: *std.ArrayList(?*T),
     marks: *std.DynamicBitSet,
     dead: *std.ArrayList(ID),
     first: *usize,
     last: *usize,
     next: *std.ArrayList(usize),
-    comptime free: fn (*T, std.mem.Allocator) ?T,
+    comptime free: fn (*T, std.mem.Allocator) void,
 ) void {
     const max_new_dead = items.items.len;
     const existing_dead = dead.items.len;
@@ -82,13 +94,11 @@ pub fn sweep(
     var id = first.*;
     while (id != end) {
         const nxt = next.items[id];
-        const slot = &items.items[id];
         if (!marks.isSet(id)) {
-            if (free(&slot.*.?, alloc)) |rep| {
-                slot.* = rep;
-            } else {
-                slot.* = null;
-            }
+            const box = items.items[id].?;
+            free(box, alloc);
+            box_pool.destroy(box);
+            items.items[id] = null;
             if (prev == end)
                 first.* = nxt
             else

--- a/src/vm/struct.zig
+++ b/src/vm/struct.zig
@@ -105,7 +105,9 @@ pub const StructInstance = struct {
 
 pub const StructInstancePool = struct {
     alloc: std.mem.Allocator,
-    instances: std.ArrayList(?StructInstance),
+    // boxed: slots hold stable *StructInstance pointers, so get() survives create().
+    box_pool: std.heap.MemoryPool(StructInstance),
+    instances: std.ArrayList(?*StructInstance),
     marks: std.DynamicBitSet,
     dead: std.ArrayList(StructInstanceID),
     first: usize = pool.end,
@@ -115,6 +117,7 @@ pub const StructInstancePool = struct {
     pub fn init(alloc: std.mem.Allocator) !StructInstancePool {
         return StructInstancePool{
             .alloc = alloc,
+            .box_pool = .empty,
             .instances = try .initCapacity(alloc, 4),
             .marks = try .initEmpty(alloc, 64),
             .dead = .empty,
@@ -123,9 +126,10 @@ pub const StructInstancePool = struct {
     }
 
     pub fn deinit(self: *StructInstancePool) void {
-        for (self.instances.items) |*maybe_s| {
-            if (maybe_s.*) |*s| s.deinit(self.alloc);
+        for (self.instances.items) |maybe_s| {
+            if (maybe_s) |s| s.deinit(self.alloc);
         }
+        self.box_pool.deinit(self.alloc);
         self.instances.deinit(self.alloc);
         self.marks.deinit();
         self.dead.deinit(self.alloc);
@@ -140,6 +144,7 @@ pub const StructInstancePool = struct {
             self.alloc,
             StructInstance,
             StructInstanceID,
+            &self.box_pool,
             &self.instances,
             &self.marks,
             &self.dead,
@@ -152,7 +157,7 @@ pub const StructInstancePool = struct {
 
     pub fn get(self: *StructInstancePool, id: StructInstanceID) !*StructInstance {
         if (id >= self.instances.items.len) return error.InvalidStruct;
-        if (self.instances.items[id]) |*s| return s;
+        if (self.instances.items[id]) |s| return s;
         return error.InvalidStruct;
     }
 
@@ -173,6 +178,7 @@ pub const StructInstancePool = struct {
             self.alloc,
             StructInstance,
             StructInstanceID,
+            &self.box_pool,
             &self.instances,
             &self.marks,
             &self.dead,
@@ -204,7 +210,6 @@ pub const StructInstancePool = struct {
     }
 };
 
-fn freeStruct(s: *StructInstance, alloc: std.mem.Allocator) ?StructInstance {
+fn freeStruct(s: *StructInstance, alloc: std.mem.Allocator) void {
     s.deinit(alloc);
-    return null;
 }

--- a/src/vm/table.zig
+++ b/src/vm/table.zig
@@ -30,7 +30,13 @@ pub const NULL_ID = std.math.maxInt(u32);
 
 pub const TablePool = struct {
     alloc: std.mem.Allocator,
-    tables: std.ArrayList(?Table),
+    // tables are boxed: the slot array holds stable *Table pointers, so a
+    // pointer from get() stays valid across later create() calls. the slot
+    // ArrayList's backing store may still move, but the boxed Table it points
+    // to does not. boxes are allocated from box_pool (arena-backed for
+    // locality) and recycled through the dead list, same as the ids.
+    box_pool: std.heap.MemoryPool(Table),
+    tables: std.ArrayList(?*Table),
     marks: std.DynamicBitSet,
     dead: std.ArrayList(memory.TableID),
     first: usize = pool.end,
@@ -40,6 +46,7 @@ pub const TablePool = struct {
     pub fn init(alloc: std.mem.Allocator) !TablePool {
         return TablePool{
             .alloc = alloc,
+            .box_pool = .empty,
             .tables = try .initCapacity(alloc, 4),
             .marks = try .initEmpty(alloc, 64),
             .dead = .empty,
@@ -48,9 +55,10 @@ pub const TablePool = struct {
     }
 
     pub fn deinit(self: *TablePool) void {
-        for (self.tables.items) |*maybe_t| {
-            if (maybe_t.*) |*t| t.deinit();
+        for (self.tables.items) |maybe_t| {
+            if (maybe_t) |t| t.deinit();
         }
+        self.box_pool.deinit(self.alloc);
         self.tables.deinit(self.alloc);
         self.marks.deinit();
         self.dead.deinit(self.alloc);
@@ -59,7 +67,7 @@ pub const TablePool = struct {
 
     pub fn create(self: *TablePool) !memory.TableID {
         if (self.dead.pop()) |id| {
-            const t = &self.tables.items[id].?;
+            const t = self.tables.items[id].?;
             t.array.clearRetainingCapacity();
             t.hash.deinit(self.alloc);
             t.metatable = null;
@@ -74,7 +82,10 @@ pub const TablePool = struct {
         if (id >= self.marks.capacity()) {
             try self.marks.resize(id + 1, false);
         }
-        try self.tables.append(self.alloc, Table.init(self.alloc));
+        const box = try self.box_pool.create(self.alloc);
+        errdefer self.box_pool.destroy(box);
+        box.* = Table.init(self.alloc);
+        try self.tables.append(self.alloc, box);
         errdefer _ = self.tables.pop();
         try pool.link(&self.first, &self.last, &self.next, self.alloc, id);
         return id;
@@ -82,7 +93,7 @@ pub const TablePool = struct {
 
     pub fn get(self: *TablePool, id: memory.TableID) !*Table {
         if (id >= self.tables.items.len) @panic("invalid table :<");
-        if (self.tables.items[id]) |*t| return t;
+        if (self.tables.items[id]) |t| return t;
         @panic("invalid table :<");
     }
 
@@ -99,18 +110,27 @@ pub const TablePool = struct {
     }
 
     pub fn sweep(self: *TablePool) void {
-        pool.sweep(
-            self.alloc,
-            Table,
-            memory.TableID,
-            &self.tables,
-            &self.marks,
-            &self.dead,
-            &self.first,
-            &self.last,
-            &self.next,
-            freeTable,
-        );
+        const alloc = self.alloc;
+        // boxes are retained and recycled through the dead list, so sweep frees
+        // each dead table's contents in place and leaves survivors' slots put.
+        // this mirrors pool.sweep but keeps the boxed *Table stable.
+        _ = self.dead.ensureTotalCapacity(alloc, self.dead.items.len + self.tables.items.len) catch return;
+        var prev: usize = pool.end;
+        var id = self.first;
+        while (id != pool.end) {
+            const nxt = self.next.items[id];
+            const t = self.tables.items[id].?;
+            if (!self.marks.isSet(id)) {
+                freeTable(t, alloc);
+                if (prev == pool.end) self.first = nxt else self.next.items[prev] = nxt;
+                self.dead.appendAssumeCapacity(@intCast(id));
+            } else {
+                self.marks.unset(id);
+                prev = id;
+            }
+            id = nxt;
+        }
+        self.last = prev;
     }
 
     pub fn bytes(self: *const TablePool) usize {
@@ -141,7 +161,7 @@ pub const TablePool = struct {
 // todo ab bench towers storage nogc
 const MAX_RETAINED_ARRAY = 16;
 
-fn freeTable(t: *Table, alloc: std.mem.Allocator) ?Table {
+fn freeTable(t: *Table, alloc: std.mem.Allocator) void {
     if (t.array.capacity > MAX_RETAINED_ARRAY) {
         t.array.deinit(t.alloc);
         t.array = .empty;
@@ -152,7 +172,6 @@ fn freeTable(t: *Table, alloc: std.mem.Allocator) ?Table {
     t.metatable = null;
     t.ic_version = 0;
     t.alloc = alloc;
-    return t.*;
 }
 
 pub const Table = struct {
@@ -622,6 +641,27 @@ test "table push appends positional values" {
     try std.testing.expectEqual(Data.new.num(10), table.getRaw(Data.new.num(0), &vm).?);
     try std.testing.expectEqual(Data.new.num(20), table.getRaw(Data.new.num(1), &vm).?);
     try std.testing.expectEqual(Data.new.num(30), table.getRaw(Data.new.num(2), &vm).?);
+}
+
+test "boxed table pointers survive pool growth from create()" {
+    var vm = try revo.VM.init(testing.runtime());
+    defer vm.deinit();
+
+    const id = try vm.tables.create();
+    const t = try vm.tables.get(id); // pointer we intend to keep using
+    try t.push(Data.new.num(1));
+
+    // grow the slot array far past its initial capacity. with inline (?Table)
+    // storage this reallocation moved the slots and left `t` dangling; boxing
+    // keeps the Table itself put, so `t` stays valid. (raw create() notes no gc
+    // pressure, so nothing is swept mid-loop and the assertions are stable.)
+    var i: usize = 0;
+    while (i < 512) : (i += 1) _ = try vm.tables.create();
+
+    try std.testing.expectEqual(@as(usize, 1), t.array.items.len);
+    try t.push(Data.new.num(2));
+    try std.testing.expectEqual(@as(usize, 2), t.array.items.len);
+    try std.testing.expectEqual(t, try vm.tables.get(id)); // same stable address
 }
 
 //

--- a/src/vm/tuple.zig
+++ b/src/vm/tuple.zig
@@ -23,7 +23,9 @@ pub const Tuple = struct {
 
 pub const TuplePool = struct {
     alloc: std.mem.Allocator,
-    tuples: std.ArrayList(?Tuple),
+    // boxed: slots hold stable *Tuple pointers, so get() survives create().
+    box_pool: std.heap.MemoryPool(Tuple),
+    tuples: std.ArrayList(?*Tuple),
     marks: std.DynamicBitSet,
     dead: std.ArrayList(memory.TupleID),
     first: usize = pool.end,
@@ -33,6 +35,7 @@ pub const TuplePool = struct {
     pub fn init(alloc: std.mem.Allocator) !TuplePool {
         return TuplePool{
             .alloc = alloc,
+            .box_pool = .empty,
             .tuples = try .initCapacity(alloc, 4),
             .marks = try .initEmpty(alloc, 64),
             .dead = .empty,
@@ -41,9 +44,10 @@ pub const TuplePool = struct {
     }
 
     pub fn deinit(self: *TuplePool) void {
-        for (self.tuples.items) |*maybe_t| {
-            if (maybe_t.*) |*t| t.deinit();
+        for (self.tuples.items) |maybe_t| {
+            if (maybe_t) |t| t.deinit();
         }
+        self.box_pool.deinit(self.alloc);
         self.tuples.deinit(self.alloc);
         self.marks.deinit();
         self.dead.deinit(self.alloc);
@@ -57,6 +61,7 @@ pub const TuplePool = struct {
             self.alloc,
             Tuple,
             memory.TupleID,
+            &self.box_pool,
             &self.tuples,
             &self.marks,
             &self.dead,
@@ -69,7 +74,7 @@ pub const TuplePool = struct {
 
     pub fn get(self: *TuplePool, id: memory.TupleID) !*Tuple {
         if (id >= self.tuples.items.len) return error.InvalidTuple;
-        if (self.tuples.items[id]) |*t| return t;
+        if (self.tuples.items[id]) |t| return t;
         return error.InvalidTuple;
     }
 
@@ -86,6 +91,7 @@ pub const TuplePool = struct {
             self.alloc,
             Tuple,
             memory.TupleID,
+            &self.box_pool,
             &self.tuples,
             &self.marks,
             &self.dead,
@@ -117,9 +123,25 @@ pub const TuplePool = struct {
     }
 };
 
-fn freeTuple(t: *Tuple, _: std.mem.Allocator) ?Tuple {
+fn freeTuple(t: *Tuple, _: std.mem.Allocator) void {
     t.deinit();
-    return null;
+}
+
+test "boxed tuple pointers survive pool growth from create()" {
+    var vm = try revo.VM.init(testing.runtime());
+    defer vm.deinit();
+
+    const id = try vm.tuples.create(&[_]Data{ Data.new.num(7), Data.new.num(8) });
+    const t = try vm.tuples.get(id); // pointer we intend to keep using
+
+    // grow the slot array far past its initial capacity; boxing keeps the Tuple
+    // itself put so `t` stays valid (raw create() notes no gc pressure).
+    var i: usize = 0;
+    while (i < 512) : (i += 1) _ = try vm.tuples.create(&[_]Data{Data.new.num(0)});
+
+    try std.testing.expectEqual(@as(usize, 2), t.items.len);
+    try std.testing.expectEqual(Data.new.num(7), t.items[0]);
+    try std.testing.expectEqual(t, try vm.tuples.get(id)); // same stable address
 }
 
 test "parses tuple literals and keeps paren grouping distinct" {


### PR DESCRIPTION
## about
fixes a type of use after free bugs where a `*Table`/`*Tuple`/etc. from a gc pool's `get()` could be left dangling by a later `create()`, then hardens the pools so the whole class can't recur. I saw one of the devs ask about it in the discord so i spent a little bit of time trying to chip in. The issue comes from the fact that every gc object pool stored its values inline in an append only array list, `get(...)` returned a pointer into that backing array. `create()` appends, which reallocates the backing store and said backing array sometimes which means that the pointers change, but the indices tho. gc can't trigger mid call, so the only trigger is `create()` between taking a pointer and using it. This isn't anything new, i see you tried to fix it in multiple places but there is a lot of other spots that held the pointer across a new allocation call.

`json.decode()` held its table pointer across `fromJsonValue` which recurses into the object and calls `vm.tables.create()`, which an reallocate the pool mid loop and then write the key into a freed pointer, i fixed this just by refetching the table each iteration. also, `debug` took the output and created a second flags table, which also can reallocate, and wrote through out a lot. i just fixed this by buildings `flags` first so `out` is taken after the last `create()`.

## fix
this is like the easiest fix ever, i just made the addresses stable. Each pool's slot array now hold `?*T` with the `T` structs allocated from `std.heap.MemoryPool`. `get()` now returns a pointer that survives any later `create()` so the realloc uaf class is impossible across every pool and the refetch after create rule is no longer load bearing anywhere. i ran the full test suite to make sure this works, Debug/ReleaseSage/ReleaseFast all build clean. 

there is just one issue which i didn't address cause i gotta go somewhere, `table:sort_by` can still dangle if the user comparator mutates the table being sorted, thats the table's own array buffer, orthogonal to the pool slots.