### PR TITLE
add is_lower? and is_upper? to std string

### DIFF
--- a/src/std/iface/string.d.rv
+++ b/src/std/iface/string.d.rv
@@ -35,6 +35,12 @@ pub declare string.starts_with? = fn(self: string, prefix: string) -> bool
 #* checks if string ends with suffix *#
 pub declare string.ends_with? = fn(self: string, suffix: string) -> bool
 
+#* checks if all characters in the string are upper case *#
+pub declare string.is_upper? = fn(self: string) -> bool
+
+#* checks if all characters in the string are lower case *#
+pub declare string.is_lower? = fn(self: string) -> bool
+
 #* reverses the string *#
 pub declare string.reverse = fn(self: string) -> string
 

--- a/src/std/string.zig
+++ b/src/std/string.zig
@@ -211,6 +211,24 @@ pub const Impl = struct {
         const sfx = vm.stringValue(@intFromEnum(suffix));
         return ._bool(std.mem.endsWith(u8, str, sfx));
     }
+
+    pub fn @"is_upper?"(vm: *VM, self: Ts.string) !HostResult {
+        const str = vm.stringValue(@intFromEnum(self));
+        if (str.len == 0)  return ._bool(false);
+        for (str) |char| {
+            if (!std.ascii.isUpper(char)) return ._bool(false);
+        }
+        return ._bool(true);
+    }
+
+    pub fn @"is_lower?"(vm: *VM, self: Ts.string) !HostResult {
+        const str = vm.stringValue(@intFromEnum(self));
+        if (str.len == 0)  return ._bool(false);
+        for (str) |char| {
+            if (!std.ascii.isLower(char)) return ._bool(false);
+        }
+        return ._bool(true);
+    }
 };
 
 pub const impls = root.impls(Impl).val;
@@ -228,6 +246,11 @@ test "string metatable" {
 
 test "string methods" {
     try testing.topTrue("\"hello\":contains?(\"ell\")");
+    try testing.topFalse("\"hello\":contains?(\"xyz\")");
+    try testing.topTrue("\"HELLO\":is_upper?");
+    try testing.topFalse("\"Hello\":is_upper?");
+    try testing.topTrue("\"hello\":is_lower?");
+    try testing.topFalse("\"Hello\":is_lower?");
     try testing.topFalse("\"hello\":contains?(\"xyz\")");
     try testing.topNumber("\"hello\":index_of(\"ll\")", 2);
     try testing.topString("string.of_ascii(97)", "a");


### PR DESCRIPTION
for the sake of onboarding and navigating around the code base, I wanted to implement something that's off of the python std string library that's simple. 