### PR TITLE
nix: fix nix flake show and improve flake usability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ __pycache__
 # gets tangled by default
 Emacs.el
 _ign*
+
+# nix build artifacts
+result
+result-*

--- a/flake.lock
+++ b/flake.lock
@@ -2,15 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788309697,
-        "narHash": "sha256-f9Ixx6NY4q7GMc0t9nhz/BC3WSfC8ihueT1p5D8V2e8=",
+        "lastModified": 1788775869,
+        "narHash": "sha256-JRf1lSypbvKj6AzUZHpUA6YC1DirVuitZWOnRwcm+Ww=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "820d011531b137b9e51e1ff117fa62f3789a0123",
+        "rev": "58973d74f1893afe13f5902919803a0e99da0ca4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,22 +1,31 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+  description = "revo, the programming language";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
   outputs =
     { self, nixpkgs }:
     let
+      inherit (nixpkgs.lib) genAttrs;
       systems = [
         "x86_64-linux"
         "aarch64-linux"
         "aarch64-darwin"
       ];
-      forEachSystem = nixpkgs.lib.genAttrs systems;
+      forSystem =
+        f: system:
+        f system (
+          import nixpkgs {
+            inherit system;
+            overlays = [ self.overlays.default ];
+          }
+        );
+      forEachSystem = f: genAttrs systems (forSystem f);
     in
     {
-      packages = forEachSystem (
-        system:
-        with nixpkgs.legacyPackages.${system};
-        rec {
-          revo = stdenv.mkDerivation {
+      overlays.default = final: _prev: {
+        revo = final.callPackage (
+          { stdenv, zig }:
+          stdenv.mkDerivation {
             name = "revo";
             version = "git";
             src = ./.;
@@ -33,43 +42,70 @@
                 };
               in
               "ln -s ${zigDeps} $ZIG_GLOBAL_CACHE_DIR/p";
-          };
-          revo-small = revo.overrideAttrs { zigBuildFlags = [ "-Dfeatures=" "-Doptimize=ReleaseSmall" ]; };
-          default = revo;
+          }
+        ) { };
 
-          build =
-            {
-              name,
-              version,
-              src,
-              entry-point ? "main",
-              revo ? revo-small,
-            }:
-            stdenv.mkDerivation {
-              inherit name version src;
-              nativeBuildInputs = [ makeWrapper ];
-              installPhase = ''
-                mkdir -p $out/revo
-                cp -r * $out/revo
-                mkdir $out/bin
-                makeWrapper "${revo}/bin/revo" "$out/bin/${name}" --add-flags "$out/revo/${entry-point}.rv"
-              '';
-            };
-          build-test = build {
+        revo-small = final.revo.overrideAttrs {
+          zigBuildFlags = [
+            "-Dfeatures="
+            "-Doptimize=ReleaseSmall"
+          ];
+        };
+
+        buildRevoModule = final.callPackage (
+          {
+            stdenv,
+            makeWrapper,
+            revo-small,
+          }:
+          {
+            name,
+            version,
+            src,
+            entry-point ? "main",
+            revo ? revo-small,
+          }:
+          stdenv.mkDerivation {
+            inherit name version src;
+            nativeBuildInputs = [ makeWrapper ];
+            installPhase = ''
+              mkdir -p $out/revo
+              cp -r * $out/revo
+              mkdir $out/bin
+              makeWrapper "${revo}/bin/revo" "$out/bin/${name}" --add-flags "$out/revo/${entry-point}.rv"
+            '';
+          }
+        ) { };
+      };
+      checks = forEachSystem (
+        _: pkgs: {
+          test = pkgs.revo.overrideAttrs (old: {
+            name = "revo-check";
+            doCheck = true;
+          });
+        }
+      );
+      packages = forEachSystem (
+        _: pkgs: {
+          inherit (pkgs) revo revo-small;
+          default = pkgs.revo;
+          modules = pkgs.buildRevoModule {
             name = "modules";
             version = "git";
             src = ./examples/modules;
           };
         }
       );
-      devShells = forEachSystem (system: {
-        default = nixpkgs.legacyPackages.${system}.mkShellNoCC {
-          packages = with nixpkgs.legacyPackages.${system}; [
-            zig
-            zig-zlint
-            zls
-          ];
-        };
-      });
+      devShells = forEachSystem (
+        _: pkgs: {
+          default = pkgs.mkShellNoCC {
+            packages = with pkgs; [
+              zig
+              zig-zlint
+              zls
+            ];
+          };
+        }
+      );
     };
 }


### PR DESCRIPTION
This PR changes the structure of the `flake.nix` to accomplish several things:

- fix `nix flake show`
- use overlays to enable easier downstream flake consumption of `revo` and module builder
- add a check to enable `nix flake check` to run `zig build test`

## `nix flake show` fixed!

Before:

```
├───devShells
│   ├───aarch64-darwin
│   │   └───default omitted (use '--all-systems' to show)
│   ├───aarch64-linux
│   │   └───default omitted (use '--all-systems' to show)
│   └───x86_64-linux
│       └───default: development environment 'nix-shell'
└───packages
    ├───aarch64-darwin
    │   ├───build omitted (use '--all-systems' to show)
    │   ├───build-test omitted (use '--all-systems' to show)
    │   ├───default omitted (use '--all-systems' to show)
    │   ├───revo omitted (use '--all-systems' to show)
    │   └───revo-small omitted (use '--all-systems' to show)
    ├───aarch64-linux
    │   ├───build omitted (use '--all-systems' to show)
    │   ├───build-test omitted (use '--all-systems' to show)
    │   ├───default omitted (use '--all-systems' to show)
    │   ├───revo omitted (use '--all-systems' to show)
    │   └───revo-small omitted (use '--all-systems' to show)
    └───x86_64-linux
error: expected a derivation
```


After:

```
├───checks
│   ├───aarch64-darwin
│   │   └───test omitted (use '--all-systems' to show)
│   ├───aarch64-linux
│   │   └───test omitted (use '--all-systems' to show)
│   └───x86_64-linux
│       └───test: derivation 'revo-check'
├───devShells
│   ├───aarch64-darwin
│   │   └───default omitted (use '--all-systems' to show)
│   ├───aarch64-linux
│   │   └───default omitted (use '--all-systems' to show)
│   └───x86_64-linux
│       └───default: development environment 'nix-shell'
├───overlays
│   └───default: Nixpkgs overlay
└───packages
    ├───aarch64-darwin
    │   ├───default omitted (use '--all-systems' to show)
    │   ├───modules omitted (use '--all-systems' to show)
    │   ├───revo omitted (use '--all-systems' to show)
    │   └───revo-small omitted (use '--all-systems' to show)
    ├───aarch64-linux
    │   ├───default omitted (use '--all-systems' to show)
    │   ├───modules omitted (use '--all-systems' to show)
    │   ├───revo omitted (use '--all-systems' to show)
    │   └───revo-small omitted (use '--all-systems' to show)
    └───x86_64-linux
        ├───default: package 'revo'
        ├───modules: package 'modules'
        ├───revo: package 'revo'
        └───revo-small: package 'revo'
```

