### PR TITLE
parser: parse foo()() as repeated calls

### DIFF
--- a/src/lang/Parser.zig
+++ b/src/lang/Parser.zig
@@ -2069,7 +2069,6 @@ const bare_call_arg_start_tokens = makeTokenSet(&.{
 });
 
 const call_stmt_boundary_tokens = makeTokenSet(&.{
-    .lparen,
     .string,
     .multiline_string,
     .lsquiggly,
@@ -2453,4 +2452,10 @@ test "declare defaults to pub" {
     const tokens = try lexer.lexAt(alloc, "declare ring = fn() -> int", .{});
     const root = try parseTokens(alloc, tokens);
     try std.testing.expect(root.expr.decl.pub_);
+}
+
+test "parses repeated paren calls" {
+    try testing.expectPrinted("f()()", "(call (call f))");
+    try testing.expectPrinted("f()()()", "(call (call (call f)))");
+    try testing.expectPrinted("f()()()()", "(call (call (call (call f))))");
 }

--- a/src/lang/tests.zig
+++ b/src/lang/tests.zig
@@ -471,7 +471,7 @@ test "sleep with multiple spawned joins returns numeric sums" {
         \\ const a = spawn f(20)
         \\ const b = spawn f(22)
         \\ const c = spawn f(30)
-        \\ (join(a) + join(b) + join(c))
+        \\ join(a) + join(b) + join(c)
     , 72);
 }
 


### PR DESCRIPTION
this means functions can return functions and be called immediately, previously it would be parsed the same as `foo(); ()`

some funny code you can write now 
```
let a = {}
a.__call = fn(a) a
a()()()()()()()()()()()()
```